### PR TITLE
Few enhancements, notably enabling a restore.sh procedure

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -73,6 +73,12 @@ function get_options {
 function get_localsettings_vars {
     LOCALSETTINGS="$INSTALL_DIR/LocalSettings.php"
 
+    if [ ! -e $LOCALSETTINGS ];then
+        echo "$LOCALSETTINGS file not found."
+        return 1
+    fi
+    echo "Reading settings from $LOCALSETTINGS."
+
     DB_HOST=`grep '^\$wgDBserver' $LOCALSETTINGS | cut -d\" -f2`
     DB_NAME=`grep '^\$wgDBname' $LOCALSETTINGS  | cut -d\" -f2`
     DB_USER=`grep '^\$wgDBuser' $LOCALSETTINGS  | cut -d\" -f2`
@@ -81,12 +87,12 @@ function get_localsettings_vars {
     # Try to extract default character set from LocalSettings.php
     # but default to binary
     DBTableOptions=$(grep '$wgDBTableOptions' $LOCALSETTINGS)
-    DB_CHARSET=$(echo $DBTableOptions | sed -E 's/.*DB_CHARSET=([^"]*).*/\1/')
+    DB_CHARSET=$(echo $DBTableOptions | sed -E 's/.*CHARSET=([^"]*).*/\1/')
     if [ -z $DB_CHARSET ]; then
         DB_CHARSET="binary"
     fi
 
-    echo "Character set in use: $DB_CHARSET"
+    echo "    Character set in use: $DB_CHARSET."
 }
 
 ################################################################################
@@ -100,7 +106,7 @@ function toggle_read_only {
     grep "$MSG" "$LOCALSETTINGS" > /dev/null
     PRESENT=$?
 
-    if [ $1 -eq "ON" ]; then
+    if [ $1 == "ON" ]; then
         if [ $PRESENT -ne 0 ]; then
             echo "Entering read-only mode"
             grep "?>" "$LOCALSETTINGS" > /dev/null
@@ -110,10 +116,10 @@ function toggle_read_only {
             else
                 echo "$MSG" >> "$LOCALSETTINGS"
             fi 
-        elif
+        else
             echo "Already in read-only mode"
         fi
-    elif [ $1 -eq "OFF" ]; then
+    elif [ $1 == "OFF" ]; then
         # Remove read-only message
         if [ $PRESENT -eq 0 ]; then 
             echo "Returning to write mode"

--- a/backup.sh
+++ b/backup.sh
@@ -85,7 +85,7 @@ function toggle_read_only {
 
     # If already read-only
     grep "$MSG" "$LOCALSETTINGS" > /dev/null
-    if [ $? -eq 0 ]; then
+    if [ $? -ne 0 ]; then
 
         echo "Entering read-only mode"
         grep "?>" "$LOCALSETTINGS" > /dev/null
@@ -160,6 +160,8 @@ BACKUP_PREFIX=$BACKUP_DIR/$(date +%Y-%m-%d)
 export_sql
 export_xml
 export_images
+
+toggle_read_only
 
 ## End main
 ################################################################################

--- a/backup.sh
+++ b/backup.sh
@@ -39,7 +39,7 @@ function usage {
 ################################################################################
 ## Get and validate CLI options
 function get_options {
-    while getopts 'h:c:d:w:s:p:f' OPT; do
+    while getopts 'hcd:w:sp:f' OPT; do
         case $OPT in
             h) usage; exit 1;;
             c) COMPLETE=true;;

--- a/backup.sh
+++ b/backup.sh
@@ -121,7 +121,7 @@ function toggle_read_only {
 ## Dump database to SQL
 ## Kudos to https://github.com/milkmiruku/backup-mediawiki
 function export_sql {
-    SQLFILE=$BACKUP_PREFIX"-database.sql.gz"
+    SQLFILE=$BACKUP_PREFIX"-database_$CHARSET.sql.gz"
     echo "Dumping database to $SQLFILE"
     nice -n 19 mysqldump --single-transaction \
         --default-character-set=$CHARSET \

--- a/backup.sh
+++ b/backup.sh
@@ -102,21 +102,21 @@ function get_options {
 function get_localsettings_vars {
     LOCALSETTINGS="$INSTALL_DIR/LocalSettings.php"
 
-    if [ ! -e $LOCALSETTINGS ];then
-        echo "$LOCALSETTINGS file not found."
+    if [ ! -e "$LOCALSETTINGS" ];then
+        echo "'$LOCALSETTINGS' file not found."
         return 1
     fi
-    echo "Reading settings from $LOCALSETTINGS."
+    echo "Reading settings from '$LOCALSETTINGS'."
 
-    DB_HOST=$(grep '^\$wgDBserver' $LOCALSETTINGS | cut -d\" -f2)
-    DB_NAME=$(grep '^\$wgDBname' $LOCALSETTINGS  | cut -d\" -f2)
-    DB_USER=$(grep '^\$wgDBuser' $LOCALSETTINGS  | cut -d\" -f2)
-    DB_PASS=$(grep '^\$wgDBpassword' $LOCALSETTINGS  | cut -d\" -f2)
+    DB_HOST=$(grep '^\$wgDBserver' "$LOCALSETTINGS" | cut -d\" -f2)
+    DB_NAME=$(grep '^\$wgDBname' "$LOCALSETTINGS"  | cut -d\" -f2)
+    DB_USER=$(grep '^\$wgDBuser' "$LOCALSETTINGS"  | cut -d\" -f2)
+    DB_PASS=$(grep '^\$wgDBpassword' "$LOCALSETTINGS"  | cut -d\" -f2)
     echo "Logging in to MySQL as $DB_USER to $DB_HOST to backup $DB_NAME"
 
     # Try to extract default character set from LocalSettings.php
     # but default to binary
-    DBTableOptions=$(grep '$wgDBTableOptions' $LOCALSETTINGS)
+    DBTableOptions=$(grep '$wgDBTableOptions' "$LOCALSETTINGS")
     DB_CHARSET=$(echo $DBTableOptions | sed -E 's/.*CHARSET=([^"]*).*/\1/')
     if [ -z $DB_CHARSET ]; then
         DB_CHARSET="binary"
@@ -130,7 +130,6 @@ function get_localsettings_vars {
 ## Kudos to http://www.mediawiki.org/wiki/User:Megam0rf/WikiBackup
 function toggle_read_only {
     local MSG="\$wgReadOnly = 'Backup in progress.';"
-    local LOCALSETTINGS="$INSTALL_DIR/LocalSettings.php"
 
     # Don't do anything if we can't write to LocalSettings.php
     if [ ! -w "$LOCALSETTINGS" ]; then

--- a/backup.sh
+++ b/backup.sh
@@ -241,7 +241,7 @@ function export_filesystem {
 ################################################################################
 ## Consolidate to one archive
 function combine_archives {
-    FULL_ARCHIVE=$BACKUP_PREFIX"-mediawiki-backup.tar.gz"
+    FULL_ARCHIVE=$BACKUP_PREFIX"-mediawiki_backup.tar.gz"
     echo "Consolidating backups into $FULL_ARCHIVE"
     # The --transform option is responsible for keeping the basename only
     tar -zcf "$FULL_ARCHIVE" $RUNNING_FILES --remove-files --transform='s|.*/||'
@@ -277,6 +277,8 @@ toggle_read_only OFF
 if [ "$SINGLE_ARCHIVE" = true ]; then
     combine_archives
 fi
+
+fi #End sourcing guard
 
 ## End main
 ################################################################################

--- a/backup.sh
+++ b/backup.sh
@@ -75,7 +75,6 @@ function get_localsettings_vars {
     DB_NAME=`grep '^\$wgDBname' $LOCALSETTINGS  | cut -d\" -f2`
     DB_USER=`grep '^\$wgDBuser' $LOCALSETTINGS  | cut -d\" -f2`
     DB_PASS=`grep '^\$wgDBpassword' $LOCALSETTINGS  | cut -d\" -f2`
-    echo "Logging in as $DB_USER to $DB_HOST to backup $DB_NAME"
 
     # Try to extract default character set from LocalSettings.php
     # but default to binary

--- a/backup.sh
+++ b/backup.sh
@@ -148,6 +148,14 @@ function export_images {
 }
 
 ################################################################################
+## Export the install directory
+function export_filesystem {
+    FS_BACKUP=$BACKUP_PREFIX"-filesystem.tar.gz"
+    echo "Compressing install directory to $FS_BACKUP"
+    tar --exclude-vcs -czhf "$FS_BACKUP" -C $INSTALL_DIR .
+}
+
+################################################################################
 ## Main
 
 # Preparation
@@ -159,7 +167,7 @@ toggle_read_only
 BACKUP_PREFIX=$BACKUP_DIR/$(date +%Y-%m-%d)
 export_sql
 export_xml
-export_images
+export_filesystem
 
 toggle_read_only
 

--- a/backup.sh
+++ b/backup.sh
@@ -5,6 +5,8 @@
 # Copyright Sam Wilson 2013 CC-BY-SA
 # http://samwilson.id.au/public/MediaWiki
 #
+# Modified by Adrien D 2013-2014
+#
 
 
 ################################################################################
@@ -188,6 +190,8 @@ function consolidate_archives {
 ################################################################################
 ## Main
 
+if [[ "$BASH_SOURCE" == "$0" ]];then
+
 # Preparation
 get_options $@
 get_localsettings_vars
@@ -211,6 +215,7 @@ consolidate_archives
 
 toggle_read_only OFF
 
+fi #End sourcing guard
 ## End main
 ################################################################################
 

--- a/backup.sh
+++ b/backup.sh
@@ -11,14 +11,26 @@
 ## Output command usage
 function usage {
     local NAME=$(basename $0)
-    echo "Usage: $NAME -d backup/dir -w installation/dir"
+    cat << EOF
+Usage: $NAME -d backup/dir -w installation/dir -c
+
+OPTIONS:
+    -h	Show this message
+    -d  The directory where the backup will be written to
+    -w  The wiki installation directory
+    -c  Make an archive with the content of the whole installation directory, instead of just the 'images' directory
+EOF
 }
 
 ################################################################################
 ## Get and validate CLI options
+COMPLETE=
+
 function get_options {
-    while getopts 'd:w:' OPT; do
+    while getopts 'hcd:w:' OPT; do
         case $OPT in
+            h) usage; exit 1;;
+            c) COMPLETE=1;;
             d) BACKUP_DIR=$OPTARG;;
             w) INSTALL_DIR=$OPTARG;;
         esac
@@ -167,7 +179,14 @@ toggle_read_only
 BACKUP_PREFIX=$BACKUP_DIR/$(date +%Y-%m-%d)
 export_sql
 export_xml
-export_filesystem
+
+# Exports files from the installation directory. Which files are exported 
+# depends on the command line arguments.
+if [ -n "$COMPLETE" ]; then
+    export_filesystem
+else
+    export_images
+fi
 
 toggle_read_only
 

--- a/backup.sh
+++ b/backup.sh
@@ -94,25 +94,31 @@ function toggle_read_only {
     local MSG="\$wgReadOnly = 'Backup in progress.';"
     local LOCALSETTINGS="$INSTALL_DIR/LocalSettings.php"
 
-    # If already read-only
+    # Verify if it is already read only
     grep "$MSG" "$LOCALSETTINGS" > /dev/null
-    if [ $? -ne 0 ]; then
+    PRESENT=$?
 
-        echo "Entering read-only mode"
-        grep "?>" "$LOCALSETTINGS" > /dev/null
-        if [ $? -eq 0 ];
-        then
-            sed -i "s/?>/\n$MSG/ig" "$LOCALSETTINGS"
-        else
-            echo "$MSG" >> "$LOCALSETTINGS"
-        fi 
-
-    # Remove read-only message
-    else
-
-        echo "Returning to write mode"
-        sed -i "s/$MSG//ig" "$LOCALSETTINGS"
-
+    if [ $1 -eq "ON" ]; then
+        if [ $PRESENT -ne 0 ]; then
+            echo "Entering read-only mode"
+            grep "?>" "$LOCALSETTINGS" > /dev/null
+            if [ $? -eq 0 ];
+            then
+                sed -i "s/?>/\n$MSG/ig" "$LOCALSETTINGS"
+            else
+                echo "$MSG" >> "$LOCALSETTINGS"
+            fi 
+        elif
+            echo "Already in read-only mode"
+        fi
+    elif [ $1 -eq "OFF" ]; then
+        # Remove read-only message
+        if [ $PRESENT -eq 0 ]; then 
+            echo "Returning to write mode"
+            sed -i "s/$MSG//ig" "$LOCALSETTINGS"
+        elif
+            echo "Already in write mode"
+        fi
     fi
 }
 
@@ -185,7 +191,7 @@ function consolidate_archives {
 # Preparation
 get_options $@
 get_localsettings_vars
-toggle_read_only
+toggle_read_only ON
 
 # Exports
 RUNNING_FILES=
@@ -203,7 +209,7 @@ fi
 
 consolidate_archives
 
-toggle_read_only
+toggle_read_only OFF
 
 ## End main
 ################################################################################

--- a/restore.sh
+++ b/restore.sh
@@ -75,7 +75,7 @@ function get_options {
 function execute_sql {
     SQL_STATEMENT=$1
     echo "Executing statement : '$SQL_STATEMENT'"
-    echo $SQL_STATEMENT | mysql -u root --password=$MYSQL_ROOT_PWD
+    echo $SQL_STATEMENT | mysql -u root --password=$MYSQL_ROOT_PWD --host=$DB_HOST 
 }
   
 function restore_database {
@@ -100,7 +100,7 @@ function restore_database_content {
     fi
 
     echo "Restoring database '$DB_NAME' from file $SQLFILE" 
-    gunzip -c $SQLFILE | mysql -u root --password=$MYSQL_ROOT_PWD $DB_NAME
+    gunzip -c $SQLFILE | mysql -u root --password=$MYSQL_ROOT_PWD --host=$DB_HOST $DB_NAME
 }
 
 ################################################################################

--- a/restore.sh
+++ b/restore.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+#
+# MediaWiki restoration script for backups made using backup.sh
+#
+# Copyright Adrien D 2014 CC-BY-SA
+#
+
+################################################################################
+## Includes backup.sh to get access to its functions
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. $DIR/backup.sh
+
+################################################################################
+## Output command usage
+function usage_restore {
+    local NAME=$(basename $0)
+    cat << EOF
+Usage: $NAME -a backup-archive -w installation/dir [-p mysql-password [-d] [-u]]
+
+OPTIONS:
+    -h	Show this message.
+    -a  The archive containing the backup.
+    -w  The wiki installation directory where the backup should be restored.
+    -p  The MySQL root password.
+    -d  Recreate the wiki MySQL database, based on the DB name found in the backup archive.
+    -u  Recreate the wiki MySQL user, based on the user found in the backup archive.
+EOF
+}
+
+################################################################################
+## Get and validate CLI options
+
+function get_options {
+    RESTORE_USER=	
+    RESTORE_DB=	
+
+    while getopts 'hdua:w:p:' OPT; do
+        case $OPT in
+            h) usage_restore; exit 1;;
+            d) RESTORE_DB=1;;
+            u) RESTORE_USER=1;;
+            a) ARCHIVE_FILE=$OPTARG;;
+            w) INSTALL_DIR=$OPTARG;;
+            p) MYSQL_ROOT_PWD=$OPTARG;;
+        esac
+    done
+
+    ## Check WIKI_WEB_DIR
+    if [ -z $INSTALL_DIR ]; then
+        echo "Please specify the wiki directory with -w" 1>&2
+        usage_restore; exit 1;
+    fi
+    if [ ! -d $INSTALL_DIR ]; then
+        mkdir --parents $INSTALL_DIR;
+	if [ ! -d $INSTALL_DIR ]; then
+            echo -n "Wiki installation directory does not exist and cannot be created" 1>&2
+            exit 1;
+        fi
+    fi
+    
+    ## Check BKP_DIR
+    if [ -z $ARCHIVE_FILE ]; then
+        echo "Please provide an archive file -a" 1>&2
+        usage_restore; exit 1;
+    fi
+    if [ ! -f $ARCHIVE_FILE ]; then
+        echo -n "Backup archive $ARCHIVE_FILE does not exist" 1>&2
+        exit 1;
+    fi
+}
+
+################################################################################
+## MySQL wiki database and user creation
+
+function execute_sql {
+    SQL_STATEMENT=$1
+    echo "Executing statement : '$SQL_STATEMENT'"
+    echo $SQL_STATEMENT | mysql -u root --password=$MYSQL_ROOT_PWD
+}
+  
+function restore_database {
+    execute_sql "create database $DB_NAME;"
+}
+
+#Information taken from here http://www.mediawiki.org/wiki/Manual:Installation/Creating_system_accounts
+#Compared to show grants for '$user'@host, which showed that 'WITH GRANT OPTION' was not set by the original installation in version 1.17
+# \note the % system is any IP, but does not work for localhost ! see http://stackoverflow.com/questions/10823854/using-for-host-when-creating-a-mysql-user
+function restore_user {
+    execute_sql "grant all privileges on $DB_NAME.* to $DB_USER@localhost.localdomain identified by '$DB_PASS';"
+    execute_sql "grant all privileges on $DB_NAME.* to $DB_USER@localhost identified by '$DB_PASS';"
+    execute_sql "grant all privileges on $DB_NAME.* to $DB_USER@'%' identified by '$DB_PASS';"
+}
+
+################################################################################
+## Database restoration
+function restore_database_content {
+    if [ -z $DB_NAME ]; then
+        echo "No database was found, cannot restore sql dump."
+        return 1
+    fi
+
+    echo "Restoring database '$DB_NAME' from file $SQLFILE" 
+    gunzip -c $SQLFILE | mysql -u root --password=$MYSQL_ROOT_PWD $DB_NAME
+}
+
+################################################################################
+## Filesystem restoration
+function restore_filesystem {
+    echo "Extracting filesystem from $FS_BACKUP"
+    tar -xzf "$FS_BACKUP" -C $INSTALL_DIR .
+}
+
+################################################################################
+## Getting the archive date
+function retrieve_archive_info {
+    ARCHIVE_DATE=${ARCHIVE_BASENAME%-*}
+    BACKUP_PREFIX=$TMP_DIR/$ARCHIVE_DATE
+
+    echo "Restoring archive $ARCHIVE_BASENAME dated of $ARCHIVE_DATE."    
+
+    # Analyze the filesystem restoration options
+    FS_BACKUP=$BACKUP_PREFIX"-filesystem.tar.gz"
+    if [ ! -e $FS_BACKUP ]; then
+        FS_BACKUP=
+    fi
+
+    # Analyze DB restoration options
+    SQLFILE=$TMP_DIR/$(ls $TMP_DIR |grep "database"|head -1)
+    _ENDSQL=${SQLFILE##*_}
+    ARCHIVE_DB_CHARSET=${_ENDSQL%%.*}
+    echo "SQL dump $(basename $SQLFILE) found, with charset $ARCHIVE_DB_CHARSET."
+}
+
+################################################################################
+## Archive expansion and clean-up
+function expand_single_archive {
+    ARCHIVE_BASENAME=$(basename $ARCHIVE_FILE)
+    TMP_DIR="/tmp/"${ARCHIVE_BASENAME%%.*}
+    mkdir -p $TMP_DIR
+    tar -xzf "$ARCHIVE_FILE" -C $TMP_DIR
+}
+
+function cleanup_archive_expansion {
+    rm -r TMP_DIR
+}
+
+################################################################################
+################################################################################
+if [[ "$BASH_SOURCE" == "$0" ]];then
+
+get_options $@
+## First restores the filesystem archive
+## This will allow us to access LocalSettings.php
+expand_single_archive
+retrieve_archive_info
+
+if [ ! -z $FS_BACKUP ]; then
+    restore_filesystem
+else
+    echo "No filesystem archive was found."
+fi
+
+## It is now possible to try reading LocalSettings.php
+get_localsettings_vars
+
+if [ ! -z $RESTORE_DB ];then
+    restore_database
+fi
+if [ ! -z $RESTORE_USER ];then
+    restore_user
+fi
+
+restore_database_content
+
+# The backup procedure would save LocalSettings in read-only mode
+toggle_read_only OFF
+
+#cleanup_archive_expansion
+
+fi # end sourcing guard

--- a/restore.sh
+++ b/restore.sh
@@ -18,7 +18,7 @@ function usage_restore {
 Usage: $NAME -a backup-archive -w installation/dir [-p mysql-password [-d] [-u]]
 
 OPTIONS:
-    -h	Show this message.
+    -h  Show this message.
     -a  The archive containing the backup.
     -w  The wiki installation directory where the backup should be restored.
     -p  The MySQL root password.
@@ -31,8 +31,8 @@ EOF
 ## Get and validate CLI options
 
 function get_options {
-    RESTORE_USER=	
-    RESTORE_DB=	
+    RESTORE_USER=
+    RESTORE_DB=
 
     while getopts 'hdua:w:p:' OPT; do
         case $OPT in
@@ -52,7 +52,7 @@ function get_options {
     fi
     if [ ! -d $INSTALL_DIR ]; then
         mkdir --parents $INSTALL_DIR;
-	if [ ! -d $INSTALL_DIR ]; then
+        if [ ! -d $INSTALL_DIR ]; then
             echo "Wiki installation directory does not exist and cannot be created" 1>&2
             exit 1;
         fi
@@ -107,7 +107,14 @@ function restore_database_content {
 ## Filesystem restoration
 function restore_filesystem {
     echo "Extracting filesystem from $FS_BACKUP"
-    tar -xzf "$FS_BACKUP" -C $INSTALL_DIR .
+    tar -xzf "$FS_BACKUP" -C $INSTALL_DIR
+}
+
+################################################################################
+## Images restoration
+function restore_images {
+    echo "Extracting images from $IMG_BACKUP"
+    tar -xzf "$IMG_BACKUP" -C $INSTALL_DIR
 }
 
 ################################################################################
@@ -122,6 +129,12 @@ function retrieve_archive_info {
     FS_BACKUP=$BACKUP_PREFIX"-filesystem.tar.gz"
     if [ ! -e $FS_BACKUP ]; then
         FS_BACKUP=
+    fi
+
+    # Analyze the images restoration options
+    IMG_BACKUP=$BACKUP_PREFIX"-images.tar.gz"
+    if [ ! -e $IMG_BACKUP ]; then
+        IMG_BACKUP=
     fi
 
     # Analyze DB restoration options
@@ -141,7 +154,7 @@ function expand_single_archive {
 }
 
 function cleanup_archive_expansion {
-    rm -r TMP_DIR
+    rm -r ${TMP_DIR}
 }
 
 ################################################################################
@@ -158,6 +171,11 @@ if [ ! -z $FS_BACKUP ]; then
     restore_filesystem
 else
     echo "No filesystem archive was found."
+    if [ ! -z $IMG_BACKUP ]; then
+        restore_images
+    else
+        echo "No image archive was found."
+    fi
 fi
 
 ## It is now possible to try reading LocalSettings.php
@@ -175,6 +193,6 @@ restore_database_content
 # The backup procedure would save LocalSettings in read-only mode
 toggle_read_only OFF
 
-#cleanup_archive_expansion
+cleanup_archive_expansion
 
 fi # end sourcing guard

--- a/restore.sh
+++ b/restore.sh
@@ -53,7 +53,7 @@ function get_options {
     if [ ! -d $INSTALL_DIR ]; then
         mkdir --parents $INSTALL_DIR;
 	if [ ! -d $INSTALL_DIR ]; then
-            echo -n "Wiki installation directory does not exist and cannot be created" 1>&2
+            echo "Wiki installation directory does not exist and cannot be created" 1>&2
             exit 1;
         fi
     fi
@@ -64,7 +64,7 @@ function get_options {
         usage_restore; exit 1;
     fi
     if [ ! -f $ARCHIVE_FILE ]; then
-        echo -n "Backup archive $ARCHIVE_FILE does not exist" 1>&2
+        echo "Backup archive $ARCHIVE_FILE does not exist" 1>&2
         exit 1;
     fi
 }


### PR DESCRIPTION
We have been diverging a bit, and it seems wasteful to maintain a fork in parallel. I'd like to merge back into yours, so it is one less fork out there, what do you think?

After quite a bit of work to manually solve conflicts, there are only a few changes to backup.sh, nothing really deep, a quick walkthrough:

* Added an option to backup the complete directory instead of just the image (just the images remains the default)
* Fix in the option parsing (some flags like `s` had a colon, making them expect a value when they do not take any)
* The archive consolidation `-s` is keeping track of the actual list of files to assemble (`$RUNNING_FILES`) instead of wildcard of all archives, allowing to keep older archives in the same backup directory without archiving them in the new archive.
* changed the follow dereference parameter to "-f" instead of the "-h", usually reserved to get help 
* `toggle_ready` expect an explicit "on" "off" argument

And of course, adds the `restore.sh` script
