### PR TITLE
backup.sh: added --no-tablespaces to mysqldump

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -176,6 +176,7 @@ function export_sql {
         --host=$DB_HOST \
         --user=$DB_USER \
         --password=$DB_PASS \
+        --no-tablespaces \
         $DB_NAME | gzip -9 > $SQLFILE
 
     # Ensure dump worked


### PR DESCRIPTION
I was getting an error when running `backup.sh`:

`mysqldump: Error: 'Access denied; you need (at least one of) the PROCESS privilege(s) for this operation' when trying to dump tablespaces`

Based on my reading of [this stackexchange answer](https://dba.stackexchange.com/a/274460/79313), my impression is that adding `--no-tablespaces` seems like a reasonable fix.  If you agree, feel free to merge in this pull request.  If you don't think that's a good idea, though, I'd love to know why!

Thanks for this!